### PR TITLE
[Minor] Fix plugin.c failing when building Bullet Plugin

### DIFF
--- a/plugins/plugin.c
+++ b/plugins/plugin.c
@@ -264,19 +264,31 @@ qboolean ZF_ReallocElements(void **ptr, size_t *elements, size_t newelements, si
 
 	//protect against malicious overflows
 	if (newelements > SIZE_MAX / elementsize)
+#ifdef __cplusplus
+		return qfalse;
+#else
 		return false;
+#endif
 
 	oldsize = *elements * elementsize;
 	newsize = newelements * elementsize;
 
 	n = plugfuncs->Realloc(*ptr, newsize);
 	if (!n)
+#ifdef __cplusplus
+		return qfalse;
+#else
 		return false;
+#endif
 	if (newsize > oldsize)
 		memset((char*)n+oldsize, 0, newsize - oldsize);
 	*elements = newelements;
 	*ptr = n;
-	return true;
+#ifdef __cplusplus
+		return qtrue;
+#else
+		return true;
+#endif
 }
 
 


### PR DESCRIPTION
I wanted to fool around with bullet, and it failed to build.

Since Bullet is written in C++, it causes this to fail to build, since we're returning `bool` instead of `qboolean`. This ensures that doesn't happen. This is done in a few other places in the engine, wonder why not here.