### PR TITLE
Fix BBoxes not visible when RTLights are used.

### DIFF
--- a/engine/client/cl_ents.c
+++ b/engine/client/cl_ents.c
@@ -2919,6 +2919,7 @@ void CLQ1_AddVisibleBBoxes(void)
 			s = R_RegisterShader("bboxshader", SUF_NONE,
 				"{\n"
 					"polygonoffset\n"
+					"sort additive\n"
 					"{\n"
 						"map $whiteimage\n"
 						"blendfunc add\n"
@@ -2975,6 +2976,7 @@ void CLQ1_AddVisibleBBoxes(void)
 	s = R_RegisterShader("bboxshader", SUF_NONE,
 		"{\n"
 			"polygonoffset\n"
+			"sort additive\n"
 			"{\n"
 				"map $whiteimage\n"
 				"blendfunc add\n"


### PR DESCRIPTION
Resolves #186
Fix given by @Shpoike

![fte-20230710091144-0](https://github.com/fte-team/fteqw/assets/21170980/d06d528e-075f-4822-a190-5a5a027b2c7a)
