### PR TITLE
Fix the clash between BBoxes and R_Polygons

### DIFF
--- a/engine/client/cl_ents.c
+++ b/engine/client/cl_ents.c
@@ -2892,6 +2892,15 @@ void CLQ1_AddVisibleBBoxes(void)
 	shader_t *s;
 	vec3_t min, max, size;
 
+	#pragma message("Temporary Code: BBoxes calling R2D_Flush")
+	/*
+	* HACK(fhomolka): For some reason, bboxes like to mess with progs-drawn Polygons.
+	* The clean way would be to understand WHY they mess with eachother, for now this must do.
+	* TODO(fhomolka)
+	* Comment by Spike: "qc's polys should have been flushed inside renderscene"
+	*/
+	if(R2D_Flush) R2D_Flush();
+
 	switch(r_showbboxes.ival & 3)
 	{
 	default:


### PR DESCRIPTION
Resolves #157 

I am not too happy with this fix, and there is probably a more correct way of solving this, as noted in the comment.
`renderscene` already calls `R2D_Flush`, but it's not guaranteed to be a poly flush at that point.
But, explicitly doing poly flushes in `renderscene` does not seem to achieve any result.

I have ran out of ideas, and this is the only thing that yielded results.