### PR TITLE
Hide consoles when showing scores.

### DIFF
--- a/engine/client/console.c
+++ b/engine/client/console.c
@@ -1800,6 +1800,12 @@ void Con_DrawNotify (void)
 {
 	extern int startuppending;
 	console_t *con;
+	int pnum;
+
+	for (pnum = 0; pnum < cl.splitclients; pnum++) {
+		if (cl.playerview[pnum].sb_showscores || cl.playerview[pnum].sb_showteamscores)
+			return;
+	}
 
 	if (con_main)
 	{


### PR DESCRIPTION
This is the same behavior as centerprints.