### PR TITLE
Allow overriding CC for cross-compilation.

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -23,8 +23,8 @@
 #note: cross compiling will typically require 'make makelibs FTE_TARGET=mytarget', which avoids installing lots of extra system packages.
 
 #
-CC=gcc
-WINDRES=windres
+CC?=gcc
+WINDRES?=windres
 STRIP?=strip
 
 STRIPFLAGS=--strip-unneeded --remove-section=.comment


### PR DESCRIPTION
In the case of SDL2 cross-compilation, I had to make this change. FTE_TARGET=SDL2_arm and such don't work. If I override the compiler with something like:
make CC=aarch64-linux-gnu-gcc then this particular line reverts it to gcc and calls the system compiler anyway. I'm not sure why this line needs to exist at all.

I did the same for windres, because it might also make sense to override it with an i686-w64-mingw32-windres. Or potentially for the aarch64-w64-mingw32 gcc in future.