### PR TITLE
Fix for newest Emscripten

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -1780,6 +1780,7 @@ ifeq ($(FTE_TARGET),web)
 	EMCC_CFLAGS+= -s FILESYSTEM=0					#we have our own.
 	EMCC_CFLAGS+= -s ALLOW_MEMORY_GROWTH=1			#reduce crashes...
 	EMCC_CFLAGS+= -s MAX_WEBGL_VERSION=2			#make use of what we can.
+	EMCC_CFLAGS+= -s TOTAL_STACK=5MB			#big!
    	EMCC_LDFLAGS+=-s ERROR_ON_UNDEFINED_SYMBOLS=1	#fairly obvious. no runtime errors please.
 	RELEASE_CFLAGS=-DOMIT_QCC -DGL_STATIC $(EMCC_CFLAGS)
 	DEBUG_CFLAGS=-g4 -DOMIT_QCC -DGL_STATIC $(EMCC_CFLAGS)

--- a/engine/common/common.c
+++ b/engine/common/common.c
@@ -25,6 +25,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <ctype.h>
 #include <errno.h>
 
+#if defined(__EMSCRIPTEN__) && !defined(__EMSCRIPTEN_major__) //ffs
+#include <emscripten/version.h>
+#endif
+
 qboolean sys_nounload;
 double		host_frametime;
 double		realtime;				// without any filtering or bounding


### PR DESCRIPTION
On [November 29 2022](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3127---112922), the Emscripten setting `STACK_SIZE` was lowered from 5MB to 64kb. FTEQW does not work with a 64kb stack, so I have upped it back to 5MB. Because the FTEQW GitHub runner uses a really old version of Emscripten, I had to use the `TOTAL_STACK` setting (it was renamed to `STACK_SIZE` on [November 8 2022](https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#3125---110822)).

Tested working with Emscripten 3.1.72-git on my Arch Linux machine.