### PR TITLE
HL2: Fix minor VMT issues regarding patch- and refraction shaders

### DIFF
--- a/plugins/hl2/glsl/vmt/refract.glsl
+++ b/plugins/hl2/glsl/vmt/refract.glsl
@@ -42,7 +42,9 @@ varying vec3 eyeminusvertex;
 
 		refr_f = texture2D( s_refraction, refl_c + ( dudv_f.st) ).rgb;
 		out_f.rgb = refr_f;
-		out_f.rgb *= texture2D( s_diffuse, tex_c).rgb;
+#ifdef TINTTEXTURE
+		out_f.rgb *= texture2D( s_diffuse, tex_c ).rgb;
+#endif
 
 		gl_FragColor = out_f;
 	}

--- a/plugins/hl2/mat_vmt.c
+++ b/plugins/hl2/mat_vmt.c
@@ -536,6 +536,9 @@ static void Shader_GenerateFromVMT(parsestate_t *ps, vmtstate_t *st, const char 
 	}
 	else if (!Q_strcasecmp(st->type, "Refract"))
 	{
+		if (*st->refracttinttexture)
+			progargs = "#TINTTEXTURE";
+
 		Q_strlcatfz(script, &offset, sizeof(script),
 			"\t{\n"
 				"\t\tprogram \"vmt/refract%s\"\n"

--- a/plugins/hl2/mat_vmt.c
+++ b/plugins/hl2/mat_vmt.c
@@ -132,7 +132,8 @@ static char *VMT_ParseBlock(const char *fname, vmtstate_t *st, char *line)
 		line = cmdfuncs->ParseToken(line, value, sizeof(value), &ttype);
 		if (ttype == TTP_RAWTOKEN && !strcmp(value, "{"))
 		{	//sub block. we don't go into details here.
-			if (!Q_strcasecmp(key, "replace"))
+			//insert and replace blocks do the same thing in practice 
+			if (!Q_strcasecmp(key, "replace") || !Q_strcasecmp(key, "insert"))
 				replace = line;
 			else
 				Con_DPrintf("%s: Unknown block \"%s\"\n", fname, key);

--- a/plugins/hl2/mat_vmt_progs.h
+++ b/plugins/hl2/mat_vmt_progs.h
@@ -245,7 +245,9 @@ YOU SHOULD NOT EDIT THIS FILE BY HAND
 
 "refr_f = texture2D( s_refraction, refl_c + ( dudv_f.st) ).rgb;\n"
 "out_f.rgb = refr_f;\n"
-"out_f.rgb *= texture2D( s_diffuse, tex_c).rgb;\n"
+"#ifdef TINTTEXTURE\n"
+"out_f.rgb *= texture2D( s_diffuse, tex_c ).rgb;\n"
+"#endif\n"
 
 "gl_FragColor = out_f;\n"
 "}\n"


### PR DESCRIPTION
This PR fixes these issues:
1. Refractive (VMT) materials without a tint texture used the normal map as tint
2. Patch textures with insert blocks would not load properly

How to test the fixes:
* For 1: The magnifying glass in HL2s d1_trainstation_05 no longer has the wrong tint
    * For the case with tint texture I used the glass box in Portal 2s sp_a3_crazy_box (only visible without physics activated)
* For 2: The leaves in overgrown Portal 2 maps render now. I have not seen insert blocks used anywhere else yet 