### PR TITLE
Fix fteqcc tripping over aliased fields

### DIFF
--- a/engine/qclib/qccmain.c
+++ b/engine/qclib/qccmain.c
@@ -4114,6 +4114,9 @@ static unsigned short QCC_PR_WriteProgdefs (char *filename)
 		if (d->type->type != ev_field)
 			continue;
 
+		if (d->symbolheader != d)
+			continue;
+
 		switch (d->type->aux_type->type)
 		{
 		case ev_float:


### PR DESCRIPTION
Was causing FTEQCC to trigger fatal error Q208 ("buggy sysdefs") over perfectly normal sysdefs, including ones created by the engine, when classes with aliased fields were used. This change fixes that issue.