### PR TITLE
Automatic cubemap building

### DIFF
--- a/engine/client/render.h
+++ b/engine/client/render.h
@@ -326,6 +326,10 @@ typedef struct refdef_s
 	vec4_t		userdata[16];		/*for custom glsl*/
 
 	qboolean	warndraw;			/*buggy gamecode likes drawing outside of te drawing logic*/
+
+	qboolean	fixedview;			/*if true, use a fixed camera setup for out-of-body screenshots (usually to build cubemaps)*/
+	vec3_t		fixedvieworg;
+	vec3_t		fixedviewangles;
 } refdef_t;
 
 extern	refdef_t	r_refdef;

--- a/engine/client/view.c
+++ b/engine/client/view.c
@@ -1591,6 +1591,38 @@ void V_ClearRefdef(playerview_t *pv)
 
 /*
 ==================
+V_CalcFixedRefDef
+
+==================
+*/
+static void V_CalcFixedRefDef (playerview_t *pv)
+{
+	r_refdef.playerview = pv;
+
+	memset(&r_refdef.globalfog, 0, sizeof(r_refdef.globalfog));
+
+	r_refdef.time = cl.servertime;
+
+// refresh position from fixed origin
+	VectorCopy(r_refdef.fixedvieworg, r_refdef.vieworg);
+
+	r_refdef.useperspective = true;
+	r_refdef.mindist = bound(0.1, gl_mindist.value, 4);
+	r_refdef.maxdist = gl_maxdist.value;
+
+	VectorCopy(r_refdef.fixedviewangles, r_refdef.viewangles);
+
+	if (v_skyroom_set)
+	{
+		r_refdef.skyroom_enabled = true;
+		VectorMA(v_skyroom_origin, v_skyroom_origin[3], r_refdef.vieworg, r_refdef.skyroom_pos);
+		Vector4Copy(v_skyroom_orientation, r_refdef.skyroom_spin);
+		r_refdef.skyroom_spin[3] *= cl.time;
+	}
+}
+
+/*
+==================
 V_CalcRefdef
 
 ==================
@@ -1599,6 +1631,12 @@ void V_CalcRefdef (playerview_t *pv)
 {
 	float		bob;
 	float		viewheight;
+
+	if (r_refdef.fixedview)
+	{
+		V_CalcFixedRefDef (pv);
+		return;
+	}
 
 	r_refdef.playerview = pv;
 


### PR DESCRIPTION
Run the "mod_buildcubemaps" command to automatically build cubemaps for each env_cubemap present in the map. It also creates the BSPX lump, if necessary. Users still have to set things like "sv_nopvs" and "r_drawentities" to their own liking. I didn't wanna send commands to the server because that'd probably require some terrible hacks.

The resulting screenshots follow the naming scheme used by BSPX_LoadEnvmaps, so they're loaded automatically the next time the map is loaded. I ran tests where the command would stuff "vid_restart" afterward. If that sounds like a good convenience feature, I can reimplement that functionality.