### PR TITLE
Adjust Quake II surface light offset when using HDR lightmaps

### DIFF
--- a/engine/common/gl_q2bsp.c
+++ b/engine/common/gl_q2bsp.c
@@ -1828,10 +1828,14 @@ static qboolean CModQ2_LoadFaces (model_t *mod, qbyte *mod_base, lump_t *l, lump
 			out->styles[i] = INVALID_LIGHTSTYLE;
 		if (lofs == ~0u)
 			out->samples = NULL;
-		else if (lightofsisdouble)
-			out->samples = mod->lightdata + (lofs/2);
 		else
+		{
+			if (lightofsisdouble)
+				lofs /= 2;
+			if (mod->lightmaps.fmt == LM_E5BGR9)
+				lofs = lofs / 3 * 4;
 			out->samples = mod->lightdata + lofs;
+		}
 
 	// set the drawing flags
 


### PR DESCRIPTION
I tweaked ericw tools to allow Quake II deluxemapping and HDR output. (ericwa/ericw-tools/pull/458) It turns out FTE doesn't render the HDR lightmaps properly, so I implemented a little fix.

If this is merged, it may be worth changing lightmap loading because right now Quake II prioritizes the vanilla lightmap lump. Maps have to be compiled with `-novanilla` to use the HDR lightmaps.

![Before](https://github.com/user-attachments/assets/67478c10-a59f-4c56-83fb-3934ed1c9542)
![After](https://github.com/user-attachments/assets/b57565c3-30dc-4470-b91a-14b1aaf3a5cf)