### PR TITLE
Fix light point deluxemap offset when using HDR lightmaps

### DIFF
--- a/engine/gl/gl_rlight.c
+++ b/engine/gl/gl_rlight.c
@@ -2795,7 +2795,7 @@ static float *GLRecursiveLightPoint3C (model_t *mod, mnode_t *node, const vec3_t
 					deluxmap = ((surf->samples - mod->lightdata)>>2)*3 + mod->deluxdata;
 
 					lightmap += (dt * ((surf->extents[0]>>surf->lmshift)+1) + ds)<<2;
-					deluxmap += (dt * ((surf->extents[0]>>surf->lmshift)+1) + ds)<<4;
+					deluxmap += (dt * ((surf->extents[0]>>surf->lmshift)+1) + ds)*3;
 					for (maps = 0 ; maps < MAXCPULIGHTMAPS && surf->styles[maps] != INVALID_LIGHTSTYLE ; maps++)
 					{
 						unsigned int lm = *(unsigned int*)lightmap;


### PR DESCRIPTION
If a map is using both deluxemapping and HDR lightmaps, entities appear to flicker as they move around. I changed the surface deluxemap offset to match the others and, with that change in place, entities appear to be lit correctly.