### PR TITLE
Emscripten: support POST requests

### DIFF
--- a/engine/http/httpclient.c
+++ b/engine/http/httpclient.c
@@ -88,11 +88,6 @@ qboolean DL_Decide(struct dl_download *dl)
 	const char *url = dl->redir;
 	if (!*url)
 		url = dl->url;
-	if (dl->postdata)
-	{	//not supported...
-		DL_Cancel(dl);
-		return false;	//safe to destroy it now
-	}
 
 	if (dl->ctx)
 	{
@@ -110,7 +105,7 @@ qboolean DL_Decide(struct dl_download *dl)
 		dl->abort = DL_Cancel;
 		dl->ctx = dl;
 
-		emscriptenfte_async_wget_data2(url, dl, DL_OnLoad, DL_OnError, DL_OnProgress);
+		emscriptenfte_async_wget_data2(url, dl->postdata, dl->postlen, dl->postmimetype, dl, DL_OnLoad, DL_OnError, DL_OnProgress);
 	}
 	else if (dl->status == DL_ACTIVE)
 	{	//canceled?
@@ -1268,11 +1263,13 @@ struct dl_download *DL_Create(const char *url)
 	newdl->qdownload.method = DL_HTTP;
 #endif
 
+#if !defined(FTE_TARGET_WEB)
 	if (!newdl->poll(newdl))
 	{
 		free(newdl);
 		newdl = NULL;
 	}
+#endif
 
 	return newdl;
 }

--- a/engine/web/ftejslib.h
+++ b/engine/web/ftejslib.h
@@ -1,5 +1,5 @@
 //emscripten's download mechanism lacks usable progress indicators.
-void emscriptenfte_async_wget_data2(const char *url, void *ctx, void (*onload)(void*ctx,int buf), void (*onerror)(void*ctx,int code), void (*onprogress)(void*ctx,int prog,int total));
+void emscriptenfte_async_wget_data2(const char *url, void *postdata, int postlen, char *postmimetype, void *ctx, void (*onload)(void*ctx,int buf), void (*onerror)(void*ctx,int code), void (*onprogress)(void*ctx,int prog,int total));
 
 //changes the page away from quake (oh noes!) or downloads something.
 void emscriptenfte_window_location(const char *url);

--- a/engine/web/ftejslib.js
+++ b/engine/web/ftejslib.js
@@ -1490,13 +1490,25 @@ mergeInto(LibraryManager.library,
 		return 0;
 	},
 
-	emscriptenfte_async_wget_data2 : function(url, ctx, onload, onerror, onprogress)
+	emscriptenfte_async_wget_data2 : function(url, postdata, postlen, postmimetype, ctx, onload, onerror, onprogress)
 	{
 		var _url = UTF8ToString(url);
 		var http = new XMLHttpRequest();
 		try
 		{
-			http.open('GET', _url, true);
+			if (postdata)
+			{
+				http.open('POST', _url, true);
+
+				if (postmimetype)
+					http.setRequestHeader("Content-Type", UTF8ToString(postmimetype));
+				else
+					http.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+			}
+			else
+			{
+				http.open('GET', _url, true);
+			}
 		}
 		catch(e)
 		{
@@ -1536,7 +1548,14 @@ mergeInto(LibraryManager.library,
 
 		try	//ffs
 		{
-			http.send(null);
+			if (postdata)
+			{
+				http.send(HEAPU8.subarray(postdata, postdata+postlen));
+			}
+			else
+			{
+				http.send(null);
+			}
 		}
 		catch(e)
 		{


### PR DESCRIPTION
adds support for sending POST requests from QuakeC with the `uri_post()` builtin in Emscripten builds. previously, you could only send GET requests due to POST requests not being implemented and silently failing.