### PR TITLE
-Fdumpopcodes: dump the opcodes enum for the selected target.

### DIFF
--- a/engine/qclib/qcc.h
+++ b/engine/qclib/qcc.h
@@ -808,6 +808,7 @@ QCC_type_t *QCC_PR_PointerType (QCC_type_t *pointsto);
 const char *QCC_VarAtOffset(QCC_sref_t ref);
 
 void QCC_PrioritiseOpcodes(void);
+pbool QCC_OPCodeValid(QCC_opcode_t *op);
 long QCC_PR_IntConstExpr(void);
 
 #ifndef COMMONINLINES

--- a/engine/qclib/qcc_pr_comp.c
+++ b/engine/qclib/qcc_pr_comp.c
@@ -704,7 +704,7 @@ QCC_opcode_t pr_opcodes[] =
 {7, "<POP>",	"POP",		PC_NONE, ASSOC_RIGHT,		&type_float,	&type_void,		&type_void},
 
 {7, "<SWITCH_I>", "SWITCH_I",PC_NONE, ASSOC_LEFT,		&type_void, NULL, &type_void},
-{7, "<>",	"GLOAD_S",		PC_NONE, ASSOC_LEFT,		&type_float,	&type_float,	&type_float},
+{7, "<>",	"GLOAD_V",		PC_NONE, ASSOC_LEFT,		&type_float,	&type_float,	&type_float},
 
 {7, "<IF_F>",	"IF_F",		PC_NONE, ASSOC_RIGHT,		&type_float, NULL, &type_void},
 {7, "<IFNOT_F>","IFNOT_F",	PC_NONE, ASSOC_RIGHT,		&type_float, NULL, &type_void},

--- a/engine/qclib/qcc_pr_comp.c
+++ b/engine/qclib/qcc_pr_comp.c
@@ -1709,7 +1709,7 @@ static pbool QCC_OPCodeValidForTarget(qcc_targetformat_t targfmt, unsigned int q
 	return false;
 }
 
-static pbool QCC_OPCodeValid(QCC_opcode_t *op)
+pbool QCC_OPCodeValid(QCC_opcode_t *op)
 {
 	return op->flags & OPF_VALID;
 }


### PR DESCRIPTION
Useful to e.g. sync between FTEQCC and DP.