### PR TITLE
Fix save/load bug preventing player movement with sv_savefmt 1/2 (fixes #374)

### DIFF
--- a/engine/qclib/initlib.c
+++ b/engine/qclib/initlib.c
@@ -499,6 +499,10 @@ void PRAddressableFlush(progfuncs_t *progfuncs, size_t totalammount)
 {
 	prinst.addressableused = 0;
 	prinst.mfreelist = 0;
+	// Clear localstack state when flushing memory
+	prinst.localstack = NULL;
+	prinst.localstack_used = 0;
+	prinst.spushed = 0;
 
 	if (totalammount <= 0)	//flush
 	{


### PR DESCRIPTION
After commit dc010d6ec, loading non-legacy saves (sv_savefmt 1 or 2) would result in players being unable to move. This seems to have been caused by localstack pointer corruption during the save/load process.

The issue seems to have occurred because:
1. Commit dc010d6ec changed localstack from a static array to dynamically allocated memory in the addressable memory region
2. When loading saves, SV_SpawnServer -> Q_InitProgs -> PR_Configure -> PRAddressableFlush would reinitialize all addressable memory
3. The localstack pointer wasn't properly cleared, causing corruption of the stringtable and breaking OP_PUSH pointers stored in saved games

The fix ensures that when addressable memory is flushed, the localstack state is properly cleared. The localstack will be correctly reallocated when progs are reloaded.