### PR TITLE
plugins: cod: fix typo that made complex number instead of unsigned int

### DIFF
--- a/plugins/cod/codbsp.c
+++ b/plugins/cod/codbsp.c
@@ -1020,7 +1020,7 @@ static qboolean CODBSP_LoadSoups (model_t *mod, qbyte *mod_base, lump_t *l)
 		mesh[i].numvertexes = LittleShort(in->vertex_count);
 
 		//cod2 sucks and is way out and results in horrible memory use. calculate what it should have been.
-		mn = ~0i;
+		mn = ~0u;
 		mx = 0;
 		for (j = 0; j < mesh[i].numindexes; j++)
 		{


### PR DESCRIPTION
`i` suffix turns literal into rarely used feature of C language: complex numbers. Probably `u` was meant here, as `mn` variable used to find minimal value from the array, and it makes more sense to initialize it to all ones.

See also: https://godbolt.org/z/fEb64e8Y6