### PR TITLE
Use WPARAM and LPARAM instead of int for WinAPI message parameters

### DIFF
--- a/engine/qclib/qccgui.c
+++ b/engine/qclib/qccgui.c
@@ -1488,8 +1488,8 @@ HWND CreateAnEditControl(HWND parent, pbool *scintillaokay)
 			while(fgets(buf, sizeof(buf)-1, f))
 			{
 				int msg;
-				int lparam;
-				int wparam;
+				LPARAM lparam;
+				WPARAM wparam;
 				char *c;
 				buf[sizeof(buf)-1] = 0;
 				c = buf;


### PR DESCRIPTION
This patch replaces `int wparam` and `int lparam` with the correct WinAPI types 
i.e. `WPARAM wparam` and `LPARAM lparam`.

`int` is only for 32-bit and cannot safely hold 64-bit pointers or values. 
This was causing fteqccgui64 to crash when loading `scintilla.cfg`. 