### PR TITLE
Preliminary support for PVR texture loading

### DIFF
--- a/engine/client/image.c
+++ b/engine/client/image.c
@@ -7188,6 +7188,11 @@ static struct pendingtextureinfo *Image_ReadBLPFile(unsigned int flags, const ch
 
 #ifdef IMAGEFMT_PVR
 
+typedef struct gbix {
+	uint32_t magic;
+	uint32_t len;
+} gbix_t;
+
 typedef struct pvr {
 	uint32_t magic;
 	uint32_t len_file;
@@ -7263,6 +7268,13 @@ qbyte *ReadPVRFile(qbyte *buf, int len, int *width, int *height, uploadfmt_t *fo
 {
 	int x, y;
 	pvr_t *pvr;
+
+	// skip gbix
+	if (memcmp(buf, "GBIX", 4) == 0)
+	{
+		gbix_t *gbix = (gbix_t *)buf;
+		buf += sizeof(gbix_t) + LittleLong(gbix->len);
+	}
 
 	// check magic identifier
 	pvr = (pvr_t *)buf;

--- a/engine/common/config_fteqw.h
+++ b/engine/common/config_fteqw.h
@@ -106,6 +106,7 @@
 #define IMAGEFMT_BMP			//windows bmp. yuck. also includes .ico for the luls
 #define IMAGEFMT_PCX			//paletted junk. required for qw player skins, q2 and a few old skyboxes.
 #define IMAGEFMT_EXR			//openexr, via Industrial Light & Magic's rgba api, giving half-float data.
+#define IMAGEFMT_PVR			//powervr texture, used by various dreamcast games including HL and Q3
 #define AVAIL_PNGLIB			//.png image format support (read+screenshots)
 #define AVAIL_JPEGLIB			//.jpeg image format support (read+screenshots)
 //#define AVAIL_STBI			//make use of Sean T. Barrett's lightweight public domain stb_image[_write] single-file-library, to avoid libpng/libjpeg dependancies.


### PR DESCRIPTION
this format was used in various Dreamcast games, including the Quake 3 and Half-Life ports.

marked as a draft for now as it doesnt yet support all the variants of PVR seen in Q3A and HL.