### PR TITLE
Fix dpmaster infoResponse and getserversResponse parsing

### DIFF
--- a/engine/client/net_master.c
+++ b/engine/client/net_master.c
@@ -2367,20 +2367,20 @@ void Master_CheckPollSockets(void)
 #ifdef HAVE_IPV6
 			if (!strncmp(s, "getserversResponse6", 19) && (s[19] == '\\' || s[19] == '/'))	//parse a bit more...
 			{
-				net_message.currentbit = (c+19-1)<<3;
+				net_message.currentbit = c+((19-1)<<3);
 				CL_MasterListParse(NA_IPV6, SS_GETINFO, true);
 				continue;
 			}
 #endif
 			if (!strncmp(s, "getserversExtResponse", 21) && (s[21] == '\\' || s[21] == '/'))	//parse a bit more...
 			{
-				net_message.currentbit = (c+21-1)<<3;
+				net_message.currentbit = c+((21-1)<<3);
 				CL_MasterListParse(NA_IP, SS_GETINFO, true);
 				continue;
 			}
 			if (!strncmp(s, "getserversResponse", 18) && (s[18] == '\\' || s[18] == '/'))	//parse a bit more...
 			{
-				net_message.currentbit = (c+18-1)<<3;
+				net_message.currentbit = c+((18-1)<<3);
 				CL_MasterListParse(NA_IP, SS_GETINFO, true);
 				continue;
 			}

--- a/engine/server/sv_main.c
+++ b/engine/server/sv_main.c
@@ -1406,6 +1406,7 @@ static void SVC_GetInfo (const char *challenge, int fullstatus)
 	*resp++ = '\n';
 
 	SV_GeneratePublicServerinfo(resp, response+sizeof(response));
+	resp += strlen(resp);
 
 	if (fullstatus)
 	{


### PR DESCRIPTION
## Summary
Two bugs that break dpmaster server browsing, especially with small server lists (1-3 servers).

### Bug 1: Empty infoResponse (sv_main.c)
`SVC_GetInfo` calls `SV_GeneratePublicServerinfo(resp, ...)` which writes the serverinfo string into the response buffer, but `resp` is never advanced afterward. `NET_SendPacket` uses `resp - response` as the packet length, so only the 17-byte header (`\xff\xff\xff\xff` + `infoResponse\n`) is sent — the actual serverinfo data is silently truncated.

**Before:** Server sends 17-byte empty infoResponse to all dpmaster queries
**After:** Server sends full ~800-byte infoResponse with hostname, map, players, etc.

### Bug 2: getserversResponse bit-position miscalculation (net_master.c)
The bit-position calculation for repositioning the message reader after matching `getserversResponse` has incorrect operator precedence:

```c
// Bug: c is in bits (e.g. 32), this computes (32+17)*8 = 392 bits = byte 49
net_message.currentbit = (c+18-1)<<3;

// Fix: correctly computes 32 + 17*8 = 168 bits = byte 21
net_message.currentbit = c+((18-1)<<3);
```

This causes the parser to start reading at byte 49 instead of byte 21. For small packets (1-3 servers, <49 bytes), it reads past the end and finds no servers. For larger packets it accidentally works by landing inside valid data (skipping a few entries).

Compare with the Q2 master response parser on the same page which correctly uses `c+(7<<3)`.

## Test plan
- [x] Tested with a FreeCS (FTEQW HL mode) dedicated server reporting to a single dpmaster
- [x] Before fix: `getinfo` returns 17-byte empty response, server browser shows 0 servers
- [x] After fix: `getinfo` returns 836-byte full response, server appears in browser with hostname/map/players
- [x] Verified via tcpdump that client sends `getinfo` probes and receives valid responses
- [x] Cross-compiled and tested on Windows x86-64 client + Linux x86-64 dedicated server

🤖 Generated with [Claude Code](https://claude.com/claude-code)