### PR TITLE
Math vector type avec(T,N,A) and vec(T,N) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,6 @@ quakec/menu.lno
 compile_commands.json
 .cache/
 
-#for qtcreator users.
-CMakeLists.txt.user
-
 # android target has a load of debris
 engine/droid/bin/
 engine/droid/gen/
@@ -44,3 +41,41 @@ engine/droid/project.properties
 
 # Flatpak build artifacts
 .flatpak-builder
+
+#for qtcreator users.
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+install_manifest.txt
+
+#data
+csaddon.dat
+csaddon.lno
+csaddon.pk3
+fteplug_cod.so
+fteplug_ezhud.so
+fteplug_ffmpeg.so
+fteplug_hl2.so
+fteplug_irc.so
+fteplug_models.so
+fteplug_qi.so
+fteplug_quake3.so
+fteplug_xmpp.so
+menu.dat
+menu.lno
+menusys.pk3
+#binaries
+ftemaster
+fteqcc
+fteqw
+fteqw-sv
+fteqw.pot
+httpserver
+imgtool
+iqmtool
+qtv
+installed.lst
+qi.cfg
+

--- a/engine/common/bothdefs.h
+++ b/engine/common/bothdefs.h
@@ -730,24 +730,63 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 	#define fte_restrict
 #endif
 
+#define BITOP_RUP01__(x) (             (x) | (             (x) >>  1))
+#define BITOP_RUP02__(x) (BITOP_RUP01__(x) | (BITOP_RUP01__(x) >>  2))
+#define BITOP_RUP04__(x) (BITOP_RUP02__(x) | (BITOP_RUP02__(x) >>  4))
+#define BITOP_RUP08__(x) (BITOP_RUP04__(x) | (BITOP_RUP04__(x) >>  8))
+#define BITOP_RUP16__(x) (BITOP_RUP08__(x) | (BITOP_RUP08__(x) >> 16))
+
+#define BITOP_LOG2__(x) (((((x) & 0xffff0000) != 0) << 4) \
+                        |((((x) & 0xff00ff00) != 0) << 3) \
+                        |((((x) & 0xf0f0f0f0) != 0) << 2) \
+                        |((((x) & 0xcccccccc) != 0) << 1) \
+                        |((((x) & 0xaaaaaaaa) != 0) << 0))
+
+#define FTE_BITCEIL(x) (const uint32_t)(BITOP_RUP16__(((uint32_t)(x)) - 1) + 1)
+#define FTE_LOG2(x)    (const uint32_t)(BITOP_LOG2__(FTE_BITCEIL(x)))
+
+/* fte_alignof(type) - get alignment of type */
+#if __STDC_VERSION__ >= 201112L
+	#include <stdalign.h>
+	#define fte_alignof(type) alignof(type)
+#elif _MSC_VER
+	#define fte_alignof(type) __alignof(type)
+#else
+	#define fte_alignof(type) sizeof(type)
+#endif
+
+/* FTE_ALIGN(a) - align to FTE_BITCEIL(a) */
 #if _MSC_VER >= 1300
-	#define FTE_ALIGN(a) __declspec(align(a))
+	#define FTE_ALIGN(a) __declspec(align(FTE_BITCEIL(a)))
 #elif defined(__clang__)
 	#define FTE_ALIGN(a) __attribute__((aligned(a)))
 #elif __GNUC__ >= 3
-	#define FTE_ALIGN(a) __attribute__((aligned(a)))
+	#define FTE_ALIGN(a) __attribute__((aligned(FTE_BITCEIL(a))))
 #else
 	#define FTE_ALIGN(a)
 #endif
 
-#if __STDC_VERSION__ >= 201112L
-	#include <stdalign.h>
-	#define fte_alignof(type) alignof(qintptr_t)
-#elif _MSC_VER
-	#define fte_alignof(type) __alignof(qintptr_t)
-#else
-	#define fte_alignof(type) sizeof(qintptr_t)
-#endif
+/* expand for permute */
+#define PARENS ()
+#define FTE_EXPAND(...) FTE_EXPAND4(FTE_EXPAND4(FTE_EXPAND4(FTE_EXPAND4(__VA_ARGS__))))
+#define FTE_EXPAND4(...) FTE_EXPAND3(FTE_EXPAND3(FTE_EXPAND3(FTE_EXPAND3(__VA_ARGS__))))
+#define FTE_EXPAND3(...) FTE_EXPAND2(FTE_EXPAND2(FTE_EXPAND2(FTE_EXPAND2(__VA_ARGS__))))
+#define FTE_EXPAND2(...) FTE_EXPAND1(FTE_EXPAND1(FTE_EXPAND1(FTE_EXPAND1(__VA_ARGS__))))
+#define FTE_EXPAND1(...) __VA_ARGS__
+
+/* define array verification and element count */
+#define fte_isarray(a  ) __builtin_choose_expr(__builtin_types_compatible_p(typeof((a)[0]) [], typeof((a))), true, false)
+#undef  fte_countof
+#define fte_countof(a  ) (sizeof((a))/sizeof((a)[0]))
+
+/* define variable argument macros */
+#define FTE_ARGSCOUNT(...) (0 __VA_OPT__(+sizeof((typeof(__VA_ARGS__)[]){__VA_ARGS__})/sizeof(__VA_ARGS__)))
+#define FTE_ARGSEMPTY(...) (true __VA_OPT__(-1))
+
+/* fte_perm(a,...) - permute array or vector */
+#define fte_perm(a,...)          { __VA_OPT__(FTE_EXPAND(fte_perm_helper(a,__VA_ARGS__))) }
+#define fte_perm_helper(a,i,...) (a)[i], __VA_OPT__(fte_perm_again PARENS (a,__VA_ARGS__))
+#define fte_perm_again()         fte_perm_helper
 
 //WARNING: FTE_CONSTRUCTOR things are unordered.
 #ifdef __cplusplus

--- a/engine/common/mathlib.h
+++ b/engine/common/mathlib.h
@@ -18,25 +18,73 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 */
 // mathlib.h
+#pragma once
 
-typedef float vec_t;
-typedef vec_t vec2_t[2];
-typedef vec_t vec3_t[3];
-typedef vec_t vec4_t[4];
-typedef vec_t vec5_t[5];
+typedef float  vec_t;
+typedef int   ivec_t;
 
-typedef int ivec_t;
-typedef ivec_t ivec2_t[2];
-typedef ivec_t ivec3_t[3];
-typedef ivec_t ivec4_t[4];
-typedef ivec_t ivec5_t[5];
+enum
+{
+	FTE_ALIGN_UNKNOWN = -1,
+	FTE_ALIGN_DEFAULT =  0 << 0,
+	FTE_ALIGN_SCALAR  =  1 << 0,
+	FTE_ALIGN_VECTOR  =  1 << 1,
+	FTE_ALIGN_MATRIX  =  1 << 2,
+	FTE_ALIGN_TENSOR  =  1 << 3,
+	FTE_ALIGN_ROTOR   =  1 << 4,
+	FTE_ALIGN_MOTOR   =  1 << 5,
+};
 
-/*16-byte aligned vectors, for auto-vectorising, should propogate to structs
-sse and altivec can unroll loops using aligned reads, which should be faster... 4 at once.
-*/
-typedef FTE_ALIGN(16) vec3_t avec3_t;
-typedef FTE_ALIGN(16) vec4_t avec4_t;
-typedef FTE_ALIGN(4) qbyte byte_vec4_t[4];
+/* define different array types */
+#pragma pack(push,1)
+#define     arr(T,N) typeof(T[N]) /* fixed static array of arbitrary length and type */
+#pragma pack(pop)
+
+#pragma pack(push,1)
+#define     vla(T  ) typeof(T[ ]) /* variable length array - VLA */
+#pragma pack(pop)
+
+#pragma pack(push,1)
+/* define vector extension power of 2 sized SIMD vector types for non MSVC */
+#ifndef _MSC_VER
+#ifdef __clang__
+#define vec_ext(T,N) typeof(T __attribute__((ext_vector_type(N))))
+#else
+#define vec_ext(T,N) typeof(T __attribute__((vector_size(FTE_BITCEIL((alignof(T) * N))))))
+#endif
+#endif
+#pragma pack(pop)
+
+#pragma pack(push,1)
+#define avec(T,N,A) \
+	FTE_ALIGN(((N * sizeof(T) == FTE_BITCEIL(N * sizeof(T)) && (A != FTE_ALIGN_SCALAR)) \
+	|| (A  > FTE_ALIGN_SCALAR) ? FTE_BITCEIL(N) : 1) * fte_alignof(T[0])) \
+arr(T,((N * sizeof(T) == FTE_BITCEIL(N * sizeof(T))) || (A > FTE_ALIGN_SCALAR) ? FTE_BITCEIL(N) : N))
+#pragma pack(pop)
+
+#define vec(T,N) avec(T,N,FTE_ALIGN_DEFAULT)
+
+typedef vec ( vec_t,2)                    vec2_t;
+typedef vec ( vec_t,3)                    vec3_t;
+typedef avec( vec_t,3,FTE_ALIGN_VECTOR)  avec3_t;
+typedef vec ( vec_t,4)                    vec4_t;
+typedef avec( vec_t,4,FTE_ALIGN_VECTOR)  avec4_t;
+typedef vec ( vec_t,5)                    vec5_t;
+typedef vec ( vec_t,6)                    vec6_t;
+typedef vec ( vec_t,7)                    vec7_t;
+typedef vec ( vec_t,8)                    vec8_t;
+
+typedef vec (ivec_t,2)                   ivec2_t;
+typedef vec (ivec_t,3)                   ivec3_t;
+typedef avec(ivec_t,3,FTE_ALIGN_VECTOR) iavec3_t;
+typedef vec (ivec_t,4)                   ivec4_t;
+typedef avec(ivec_t,4,FTE_ALIGN_VECTOR) iavec4_t;
+typedef vec (ivec_t,5)                   ivec5_t;
+typedef vec (ivec_t,6)                   ivec6_t;
+typedef vec (ivec_t,7)                   ivec7_t;
+typedef vec (ivec_t,8)                   ivec8_t;
+
+typedef vec ( qbyte,4)               byte_vec4_t;
 
 //VECV_STRIDE is used only as an argument for opengl.
 #ifdef FTE_TARGET_WEB

--- a/fteqtv/qtv.h
+++ b/fteqtv/qtv.h
@@ -297,7 +297,7 @@ size_t CalcHMAC(hashfunc_t *hashfunc, unsigned char *digest, size_t maxdigestsiz
 
 
 #if !defined(__cplusplus) && (!defined(__STDC_VERSION__) || (defined(__STDC_VERSION__) && (__STDC_VERSION__ < 202311L)))
-typedef enum {false, true} qboolean;
+typedef enum {qfalse = (const int)false, qtrue = (const int)true} qboolean;
 #else
 typedef int qboolean;
 #endif


### PR DESCRIPTION
Sorry to resubmit after lost account please close #403 

- add ignores in source tree build
- add `FTE_BITCEIL(x)` based on `BITOP_RUP16__(x)` to round to next power of two
- add `FTE_LOG2(x)` for base 2 logarithm
- use `type` in `fte_alignof` instead of `qinptr_t`
- add `fte_isarray`, `fte_countof`
- add `FTE_ARGSCOUNT`, `FTE_ARGSEMPTY` for preprocessor variable argument counting
- add `fte_perm` restricted length intializer list permute array/vector
- add arbitrary length/type `avec(T,N,A)` with different alignment modes
- use `avec(T,N,FTE_ALIGN_DEFAULT)` as `vec(T,N)` that is aligned if size is a power of two otherwise scalar alignment is used.
- add `vec_ext(T,N)` for compiler vector types that are always pad aligned to power of two
- add defines for quake vector types up to 8 elements count
- add cast to `(const int)` in `qboolean`

**TODO**
- check zero alignment error reason:
```sh
[  7%] Linking C shared module fteplug_quake3.so
[  8%] Building C object CMakeFiles/fteqw-sv.dir/engine/common/com_mesh.c.o
[  8%] Building C object CMakeFiles/fteqw.dir/engine/client/cl_main.c.o
In file included from /mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/quakedef.h:172,
                 from /mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/iqm/../plugins/plugin.h:8,
                 from /mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/iqm/iqm.cpp:7:
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:55:44: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   55 | typedef vec  ( vec_t,2)                    vec2_t;
      |                                            ^~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:56:44: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   56 | typedef vec  ( vec_t,3)                    vec3_t;
      |                                            ^~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:57:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   57 | typedef avecn( vec_t,3,FTE_ALIGN_VECTOR)  avec3_t;
      |                                           ^~~~~~~
[  8%] Building C object CMakeFiles/ftemaster.dir/engine/common/fs_stdio.c.o
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:58:44: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   58 | typedef vec  ( vec_t,4)                    vec4_t;
      |                                            ^~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:59:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   59 | typedef avecn( vec_t,4,FTE_ALIGN_VECTOR)  avec4_t;
      |                                           ^~~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:60:44: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   60 | typedef vec  ( vec_t,5)                    vec5_t;
      |                                            ^~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:61:44: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   61 | typedef vec  ( vec_t,6)                    vec6_t;
      |                                            ^~~~~~
[  9%] Building C object CMakeFiles/ftemaster.dir/engine/common/log.c.o
[  9%] Building C object CMakeFiles/fteqw.dir/engine/client/cl_parse.c.o
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:62:44: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   62 | typedef vec  ( vec_t,7)                    vec7_t;
      |                                            ^~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:63:44: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   63 | typedef vec  ( vec_t,8)                    vec8_t;
      |                                            ^~~~~~
[  9%] Building C object CMakeFiles/ftemaster.dir/engine/common/net_ice.c.o
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:65:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   65 | typedef vec  (ivec_t,2)                   ivec2_t;
      |                                           ^~~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:66:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   66 | typedef vec  (ivec_t,3)                   ivec3_t;
      |                                           ^~~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:67:42: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   67 | typedef avecn(ivec_t,3,FTE_ALIGN_VECTOR) iavec3_t;
      |                                          ^~~~~~~~
[ 10%] Building C object CMakeFiles/fteqw.dir/engine/client/cl_pred.c.o
[ 10%] Building C object CMakeFiles/fteqw-sv.dir/engine/common/common.c.o
[ 10%] Building C object CMakeFiles/ftemaster.dir/engine/common/net_ssl_gnutls.c.o
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:68:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   68 | typedef vec  (ivec_t,4)                   ivec4_t;
      |                                           ^~~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:69:42: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   69 | typedef avecn(ivec_t,4,FTE_ALIGN_VECTOR) iavec4_t;
      |                                          ^~~~~~~~
Zip entry offsets appear off by 81104 bytes - correcting...
[ 10%] Built target plug_cod
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:70:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   70 | typedef vec  (ivec_t,5)                   ivec5_t;
      |                                           ^~~~~~~
[ 10%] Building C object CMakeFiles/fteqw.dir/engine/client/cl_screen.c.o
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:71:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   71 | typedef vec  (ivec_t,6)                   ivec6_t;
      |                                           ^~~~~~~
[ 10%] Building C object CMakeFiles/ftemaster.dir/engine/common/net_wins.c.o
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:72:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   72 | typedef vec  (ivec_t,7)                   ivec7_t;
      |                                           ^~~~~~~
[ 11%] Building C object CMakeFiles/fteqw-sv.dir/engine/common/crc.c.o
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:73:43: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   73 | typedef vec  (ivec_t,8)                   ivec8_t;
      |                                           ^~~~~~~
/mnt/hd/usr/src/engine/id/fteqw/joneqdaniel/fteqw/engine/client/../common/mathlib.h:75:39: warning: requested alignment ‘0’ is not a positive power of 2 [-Wattributes]
   75 | typedef vec  ( qbyte,4)               byte_vec4_t;
      |                                       ^~~~~~~~~~~
[ 11%] Building C object CMakeFiles/fteqw.dir/engine/client/cl_tent.c.o

```