### PR TITLE
ffmpeg: fix avdecode blocking forever decoding most containers

### DIFF
--- a/plugins/avplug/avdecode.c
+++ b/plugins/avplug/avdecode.c
@@ -89,11 +89,14 @@ static qboolean AVDec_SetSize (void *vctx, int width, int height)
 static int AVIO_Read(void *opaque, uint8_t *buf, int buf_size)
 {
 	struct decctx *ctx = opaque;
-	int ammount;
-	ammount = VFS_READ(ctx->file, buf, buf_size);
-	if (ammount > 0)
-		ctx->fileofs += ammount;
-	return ammount;
+	int amount;
+	amount = VFS_READ(ctx->file, buf, buf_size);
+	if (amount > 0) {
+		ctx->fileofs += amount;
+	} else {
+		return AVERROR_EOF;
+	}
+	return amount;
 }
 static int64_t AVIO_Seek(void *opaque, int64_t offset, int whence)
 {


### PR DESCRIPTION
cherry-picked from [interrupt's fork](https://codeberg.org/Interrupt/fteqw)
commit message:
```
fteqw seems to have decided to begin to move away from the legacy
ffmpeg 4 it was using, which is awesome, but it would seem it was done
somewhat untestedly.

this commit specifically addresses a bug in which the game would end up
entirely blocked by AVIO_Read on the majority of contemporary video
containers besides mp4 since at some point between ffmpeg 4 to 8 (wow!)
it now expects the read callback to return a proper AVERROR code, and
crucially, it seems it is not ever supposed to return 0, which was the
behavior when we were out of stuff to read, thus causing ffmpeg to just
retry it's read forever, it seems. so now we give it AVERROR_EOF when
we're out of stuff to give it!
```