### PR TITLE
fteqcc: fix crash when encountering errors

### DIFF
--- a/engine/qclib/qcc_pr_lex.c
+++ b/engine/qclib/qcc_pr_lex.c
@@ -4162,9 +4162,12 @@ NORETURN void VARGS QCC_PR_ParseError (int errortype, const char *error, ...)
 	va_list		argptr;
 	char		string[1024];
 
-	va_start (argptr,error);
-	QC_vsnprintf (string,sizeof(string)-1, error,argptr);
-	va_end (argptr);
+	if (error)
+	{
+		va_start (argptr,error);
+		QC_vsnprintf (string,sizeof(string)-1, error,argptr);
+		va_end (argptr);
+	}
 
 #ifndef QCC
 	editbadfile(s_filen, pr_source_line);


### PR DESCRIPTION
was causing FTEQCC to segfault whenever it encountered an error on my system.