### PR TITLE
vk: include <limits.h> in vk_init.c for UINT_MAX

### DIFF
--- a/engine/vk/vk_init.c
+++ b/engine/vk/vk_init.c
@@ -7,6 +7,8 @@
 
 #include "vr.h"
 
+#include <limits.h>	//for UINT_MAX
+
 extern qboolean vid_isfullscreen;
 
 cvar_t vk_stagingbuffers						= CVARFD ("vk_stagingbuffers",			"", CVAR_RENDERERLATCH, "Configures which dynamic buffers are copied into gpu memory for rendering, instead of reading from shared memory. Empty for default settings.\nAccepted chars are u(niform), e(lements), v(ertex), 0(none).");


### PR DESCRIPTION
engine/vk/vk_init.c references UINT_MAX but does not include <limits.h>, relying on it being pulled in transitively. When the Vulkan headers are installed (so VKQUAKE is enabled), the CMake build fails to compile vk_init.c with `error: use of undeclared identifier 'UINT_MAX'` (seen here at vk_init.c:4869 with Apple clang). The Makefile gl-rel target does not compile the vk backend, which is why upstream CI has not hit it. Adding `#include <limits.h>` fixes the build; no behavioural change.