### PR TITLE
Guideline Changes

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,4 @@
+### Checklist
+---
+
+- [ ] I have read the FTEQW guidelines on reporting issues and have included all the required information (including Operating System, hardware, FTEQW version, etc)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+### Checklist
+---
+
+- [ ] This PR contains no AI-generated or assisted code
+- [ ] I have read the FTEQW contribution guidelines

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ Contributions and help is always welcomed.
 ### Guidelines:
 
 - Be kind and respectful
-- GPL2 licensed contributions are preferred, but plugins can be different but GPL-compatbile licenses
-- This codebase follows USA/EU/UK copyright laws
+- We follow [Gentoo's AI policy](https://wiki.gentoo.org/wiki/Project:Council/AI_policy), **_It is expressly forbidden to contribute any content that has been created with the assistance of Natural Language Processing artificial intelligence tools. This motion can be revisited, should a case been made over such a tool that does not pose copyright, ethical and quality concerns._** IBM also has a [great page](https://www.ibm.com/docs/en/watsonx/saas?topic=ai-risk-atlas) listing the many risks with current language models
+- Engine contributions must be GPL2 licensed. Plugins may be under any other GPL-compatbile licenses
+- This codebase follows [TRIPS copyright laws](https://en.wikipedia.org/wiki/TRIPS_Agreement)
 - Always give credit from other codebases and make sure licenses are compatible
 - Test your changes and ensure nothing else has been broken (games, plugins, formats, etc)
 


### PR DESCRIPTION
- Change guidelines to address and disallow Neural Network assisted contributions
- Clarify engine vs plugins license contributions
- Mention TRIPS instead of just USA/EU/UK
- Add minimal templates for PRs and Issues